### PR TITLE
add option for detaching from console

### DIFF
--- a/lib/workspace/commands/service.rb
+++ b/lib/workspace/commands/service.rb
@@ -34,7 +34,7 @@ module Workspace
 
       desc 'start SERVICE', 'Starts up the specified service'
       option :build, type: :boolean
-      option :detach, :type => :boolean, :aliases => :d, desc: 'provide documentation here'
+      option :detach, :type => :boolean, :aliases => :d, desc: 'Detach from the container after start up'
       def start(service)
         root = service_root(service)
         environments = Workspace.configuration.services.dig(service, 'environments') || []
@@ -44,7 +44,7 @@ module Workspace
           append_file("#{root}/.env", File.read("environments/#{env}"))
         end
 
-        docker("compose --file #{root}/docker-compose.yml up #{options[:d] ? '-d' : nil} #{options[:build] ? '--build' : nil}")
+        docker("compose --file #{root}/docker-compose.yml up #{options[:detach] ? '-d' : nil} #{options[:build] ? '--build' : nil}")
       end
 
       desc 'clean SERVICE', 'Cleans the service container back to defaults'

--- a/lib/workspace/commands/service.rb
+++ b/lib/workspace/commands/service.rb
@@ -34,6 +34,7 @@ module Workspace
 
       desc 'start SERVICE', 'Starts up the specified service'
       option :build, type: :boolean
+      option :d, type: :boolean
       def start(service)
         root = service_root(service)
         environments = Workspace.configuration.services.dig(service, 'environments') || []
@@ -43,7 +44,7 @@ module Workspace
           append_file("#{root}/.env", File.read("environments/#{env}"))
         end
 
-        docker("compose --file #{root}/docker-compose.yml up #{options[:build] ? '--build' : nil}")
+        docker("compose --file #{root}/docker-compose.yml up #{options[:d] ? '-d' : nil} #{options[:build] ? '--build' : nil}")
       end
 
       desc 'clean SERVICE', 'Cleans the service container back to defaults'

--- a/lib/workspace/commands/service.rb
+++ b/lib/workspace/commands/service.rb
@@ -34,7 +34,7 @@ module Workspace
 
       desc 'start SERVICE', 'Starts up the specified service'
       option :build, type: :boolean
-      option :d, type: :boolean
+      option :detach, :type => :boolean, :aliases => :d, desc: 'provide documentation here'
       def start(service)
         root = service_root(service)
         environments = Workspace.configuration.services.dig(service, 'environments') || []


### PR DESCRIPTION
resolves #6 

Allows you to detach from the output when the container starts.

`workspace service start mongo -d`

This allows the container to run in the background.