### PR TITLE
Add .gitignore and README.md to generator

### DIFF
--- a/lib/generators/services/README.md
+++ b/lib/generators/services/README.md
@@ -1,0 +1,7 @@
+# <%= config[:service] %>
+
+_Describe the service. What it's running, what it's based on, etc._
+
+## Setup
+
+_Explain the required steps to get this service up and running._

--- a/lib/workspace/commands/service.rb
+++ b/lib/workspace/commands/service.rb
@@ -19,6 +19,8 @@ module Workspace
         empty_directory("#{root}")
         empty_directory("#{root}/data")
         create_file("#{root}/data/.gitkeep")
+        create_file("#{root}/.gitignore")
+        template('lib/generators/services/README.md', "#{root}/README.md", service: service)
         template('lib/generators/services/Dockerfile', "#{root}/Dockerfile", image: options[:image])
         props = { service: service }
         props.merge!(platform: options[:platform]) if options[:platform]


### PR DESCRIPTION
Closes #40 

Adds a default `.gitignore` and `README.md` to the service when created with the generator.